### PR TITLE
makes getMaxDist aware of CRS

### DIFF
--- a/R/predict.gstat.R
+++ b/R/predict.gstat.R
@@ -232,9 +232,19 @@ create.gstat.names <- function(ids, names.sep = ".") {
 }
 
 getMaxDist = function(dataLst, newdata) {
-	d = apply(bbox(newdata), 1, diff)
+  
+  spBbox <- SpatialPoints(cbind(newdata@bbox[cbind(c(1,1,1,1), c(1,2,1,1))],
+                                newdata@bbox[cbind(c(2,2,2,2), c(1,1,1,2))]), 
+                          proj4string = newdata@proj4string)
+  d <- c(spDists(spBbox)[cbind(c(1,3),c(2,4))])
+  
+	# d = apply(bbox(newdata), 1, diff)
 	if (!is.null(dataLst[[1]]$data)) {
-		d2 = apply(bbox(dataLst[[1]]$data), 1, diff)
+	  spBbox2 <- SpatialPoints(cbind(dataLst[[1]]$data@bbox[cbind(c(1,1,1,1), c(1,2,1,1))],
+	                                 dataLst[[1]]$data@bbox[cbind(c(2,2,2,2), c(1,1,1,2))]), 
+	                          proj4string = dataLst[[1]]$data@proj4string)
+	  d2 <- c(spDists(spBbox2)[cbind(c(1,3),c(2,4))])
+		# d2 = apply(bbox(dataLst[[1]]$data), 1, diff)
 		d = apply(rbind(d,d2), 2, max) 
 		# there are pathetic cases where this would not be sufficient 
 	}


### PR DESCRIPTION
before, max_dist used in predict.gstat was based on a "simple" diff of the bounding-box leading to mismatching units of measurement when unprojected data was provided (km in the variogram model and ° in max_dist).

